### PR TITLE
Add [CEReactions] annotation to disableRemotePlayback

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
         partial interface HTMLMediaElement {
           readonly attribute RemotePlayback remote;
 
-          attribute boolean disableRemotePlayback;
+          [CEReactions] attribute boolean disableRemotePlayback;
         };
       </pre>
       <p>


### PR DESCRIPTION
Since the disableRemotePlayback attribute can change the DOM in ways that may impact custom elements, it needs to be annotated with the [CEReactions] attribute. This is part of the larger effort at w3c/webcomponents#186. [CEReactions] is defined in https://html.spec.whatwg.org/multipage/scripting.html#cereactions.

(Blink's counterpart is [CustomElementCallbacks], FYI)
