### PR TITLE
Adjust styles for official 2016 stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,25 +80,6 @@
     .non-normative { border-left-style: solid; border-left-width: 0.25em; background: none repeat scroll 0 0 #E9FBE9; border-color: #52E052; }
     p.non-normative:before { content: 'Non-normative: '; font-weight: bolder;}
     p.non-normative, div.non-normative { padding: 0.5em 2em; }
-    /* Pre.idl formatting taken from HTML5 spec */
-    pre.idl { border: solid thin #d3d3d3; background: #FCFCFC; color: black; padding: 0.5em 1em; position: relative; }
-    pre.idl :link, pre.idl :visited { color: inherit; background: transparent; }
-    pre.idl::before { content: "IDL"; font: bold small sans-serif;
-    padding: 0.5em; background: white; position: absolute; top: 0;
-    margin: -1px 0 0 -4em; width: 1.5em; border: thin solid;
-    border-radius: 0 0 0 0.5em }
-    /* .example idl formatting taken from HTML5 nightly spec */
-    .example {
-        display: block;
-        color: #222222;
-        background: #FCFCFC;
-        border-left-style: solid;
-        border-color: #c0c0c0;
-        border-left-width: 0.25em;
-        margin-left: 1em;
-        padding-left: 1em;
-        padding-bottom: 0.5em;
-    }
     .algorithm li {
         margin-bottom: 0.5em;
     }


### PR DESCRIPTION
The custom styles that we had for IDL declarations caused the "WebIDL" banner to appear truncated.

Same changes as those made to the Presentation API some time ago:
https://github.com/w3c/presentation-api/pull/270
