### PR TITLE
Dependencies/Terminology clean-up.

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,46 +190,44 @@
       </p>
       <ul>
         <li>
-          <dfn><a href=
-          'https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement'>HTMLMediaElement</a></dfn>
+          <dfn><a href='https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement'>HTMLMediaElement</a></dfn>,
+          <dfn><a href='https://html.spec.whatwg.org/multipage/embedded-content.html#media-element'>media element</a></dfn>,
+          <dfn data-lt="resource selection algorithm">
+            <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#concept-media-load-algorithm">selecting media resource</a></dfn> and
+          <dfn><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#location-of-the-media-resource">media resource</a></dfn>
         </li>
         <li>
-          <dfn><a href='https://html.spec.whatwg.org/multipage/embedded-content.html#media-element'>media element</a></dfn>
+          <dfn><a href='https://html.spec.whatwg.org/multipage/browsers.html#browsing-context'>browsing context</a></dfn> and
+          <dfn><a href='https://html.spec.whatwg.org/multipage/browsers.html#allowed-to-show-a-popup'>allowed to show a popup</a></dfn>
+        </li>
+        <li>
+          <dfn><a href='https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers'>event handler</a></dfn>,
+          <dfn><a href='https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type'>event handler event type</a></dfn>,
+          <dfn><a href='https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-simple-event'>fire a simple event</a></dfn> and
+          <dfn><a href='https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task'>queue a task</a></dfn>
+        </li>
+        <li>
+          <dfn data-lt='fire|fires'><a href='https://html.spec.whatwg.org/multipage/infrastructure.html#concept-event-fire'>firing an event</a></dfn> and
+          <dfn><a href='https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel'>in parallel</a></dfn>,
+        </li>
+        <li>
+          <dfn><a href='https://html.spec.whatwg.org/multipage/scripting.html#cereactions'><code>[CEReactions]</code></a></dfn>
         </li>
       </ul>
-    </section>
-    <section>
-      <h2>
-        Terminology
-      </h2>
+
       <p>
-        The terms <dfn><a href= "http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing context</a></dfn>,
-        <dfn><a href="http://www.w3.org/TR/html5/webappapis.html#event-handlers">event handler</a></dfn>,
-        <dfn><a href="http://www.w3.org/TR/html5/webappapis.html#event-handler-event-type">
-          event handler event type</a></dfn>,
-        <dfn data-lt="fire|fires"><a href="http://www.w3.org/TR/html5/infrastructure.html#concept-event-fire">
-          firing an event</a></dfn>,
-        <dfn data-lt="fire a simple event"><a href="http://www.w3.org/TR/html5/webappapis.html#fire-a-simple-event">
-          firing a simple event</a></dfn>,
-        <dfn><a href="http://www.w3.org/TR/html5/webappapis.html#queue-a-task">queue a task</a></dfn>,
-        <dfn><a href="http://www.w3.org/TR/html5/browsers.html#allowed-to-show-a-popup">
-          allowed to show a popup</a></dfn>,
-        <dfn data-lt="resource selection algorithm">
-          <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#concept-media-load-algorithm">
-            selecting media resource</a></dfn>,
-        <dfn><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#location-of-the-media-resource">
-          media resource</a></dfn>
-        are defined in [[!HTML5]].
+        The term <dfn><a href="https://url.spec.whatwg.org/#url">URL</a></dfn>
+        is defined in the WHATWG URL standard [[!URL]].
       </p>
-      <p>
-        The term <dfn><a href=
-        "http://www.w3.org/TR/html51/infrastructure.html#in-parallel">in
-        parallel</a></dfn> is defined in [[!HTML51]].
-      </p>
+
       <p>
         The term <dfn>throw</dfn> in this specification is used as defined in
-        [[!WEBIDL]]. The following exception names are defined by WebIDL and
-        used by this specification:
+        [[!WEBIDL]].
+      </p>
+
+      <p>
+        The following exception names are defined by [[!WEBIDL]] and used by
+        this specification:
       </p>
       <ul>
         <li>
@@ -245,15 +243,7 @@
           <dfn><code>OperationError</code></dfn>
         </li>
       </ul>
-      <p>
-        The <dfn><a href="https://html.spec.whatwg.org/multipage/scripting.html#cereactions"><code>[CEReactions]</code></a></dfn>
-        IDL extended attribute is defined in [[!HTML]].
-      </p>
-      <p>
-        The term <dfn><a href="https://url.spec.whatwg.org/#url">URL</a></dfn>
-        is defined in the WHATWG URL standard [[!URL]].
-      </p>
-    </section>    
+    </section>
     <section>
       <h2>
         Examples


### PR DESCRIPTION
This is merging the two sections into one. It is also using one HTML
reference instead of three (HTML, HTML5, HTML51).
