### PR TITLE
Adds customized paragraph to SoTD that mentions the Presentation API

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
             company: 'Google',
           },
         ],
+        sotdAfterWGinfo: true,
         // previousMaturity: 'WD',
         // previousPublishDate: '2015-11-02',
         otherLinks: [
@@ -104,8 +105,12 @@
     </section>
     <section id="sotd">
       <p>
-        This document is a work in progress and is subject to change. In case of
-        issues or concerns, it is possible to <a href='https://github.com/w3c/remote-playback/issues/new'>file a bug</a>
+        This document is a <strong>work in progress</strong> and is subject to
+        change. It builds on the group's experience on presenting web content on
+        external presentation-type displays, and re-uses patterns and design
+        considerations from the Presentation API specification whenever
+        appropriate [[PRESENTATION-API]]. In case of issues or concerns, it is
+        possible to <a href='https://github.com/w3c/remote-playback/issues/new'>file a bug</a>
         or send an email to the <a href='https://lists.w3.org/Archives/Public/public-secondscreen/'>mailing list</a>.
         For small editorial changes like typos, sending a pull request is appreciated.
       </p>


### PR DESCRIPTION
This update intents to fulfill the following pubrules SoTD requirement:
"It MUST include at least one customized paragraph. This section SHOULD include the title page date (i.e., the one next to the maturity level at the top of the document). These paragraphs SHOULD explain the publication context, including rationale and relationships to other work."
https://www.w3.org/pubrules/doc/rules/?profile=FPWD#customParagraph

While the Remote Playback API does not depend on the Presentation API in practice, it seems important to present it in the context of the work on the Presentation API.
