### PR TITLE
Tell ReSpec to use W3C Software and Document License for the spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
           },
         ],
         sotdAfterWGinfo: true,
+        license: "w3c-software-doc",
         // previousMaturity: 'WD',
         // previousPublishDate: '2015-11-02',
         otherLinks: [


### PR DESCRIPTION
The charter of the Second Screen WG is explicit that the group will use the W3C Software and Document License for all its deliverable:
http://www.w3.org/2014/secondscreen/charter-2016.html#licensing

Now, that seems to have fallen through the cracks until now as drafts have actually been published under the more restrictive W3C Document License.