### PR TITLE
Adds notes about controls and playback.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1127,7 +1127,7 @@
           </div>
           <div class="note">
             The user agent SHOULD pause local audio and video output of the
-            media element while remote playback
+            media element while the <a>remote playback state</a>
             is <a data-link-for="RemotePlaybackState">connected</a>.
           </div>
           <div class="note">

--- a/index.html
+++ b/index.html
@@ -252,7 +252,7 @@
           "currentSrc"><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-currentsrc">
           current source</a></dfn> and <dfn data-lt="media resources"><a href=
           "https://html.spec.whatwg.org/multipage/embedded-content.html#location-of-the-media-resource">
-          media resource</a></dfn> <dfn><a href=
+          media resource</a></dfn> <dfn data-lt="exposing a user interface to the user"><a href=
           "https://html.spec.whatwg.org/multipage/embedded-content.html#expose-a-user-interface-to-the-user">
           expose a user interface to the user</a></dfn>
         </li>
@@ -1130,6 +1130,17 @@
             playback device and receiving media playback state in order to keep
             the <a>media element state</a> and <a>remote playback state</a> in
             sync (unless <a>media mirroring</a> is used).
+          </div>
+          <div class="note">
+            The user agent SHOULD pause local audio and video output of the
+            media element while remote playback
+            is <a data-link-for="RemotePlaybackState">connected</a>.
+          </div>
+          <div class="note">
+            If the user agent is <a>exposing a user interface to the user</a>
+            for the media element (i.e., using default controls), the user agent
+            SHOULD convey the fact that remote playback is connected through an
+            icon or other means.
           </div>
         </section>
         <section>

--- a/index.html
+++ b/index.html
@@ -1133,7 +1133,8 @@
           <div class="note">
             If the user agent is <a>exposing a user interface to the user</a>
             for the media element (i.e., using default controls), the user agent
-            SHOULD convey the fact that remote playback is connected through an
+            SHOULD convey the fact that <a>remote playback state</a>
+            is <a data-link-for="RemotePlaybackState">connected</a> through an
             icon or other means.
           </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -1133,7 +1133,7 @@
           <div class="note">
             If the user agent is <a>exposing a user interface to the user</a>
             for the media element (i.e., using default controls), the user agent
-            SHOULD convey the fact that <a>remote playback state</a>
+            SHOULD convey the fact that the <a>remote playback state</a>
             is <a data-link-for="RemotePlaybackState">connected</a> through an
             icon or other means.
           </div>


### PR DESCRIPTION
Addresses Issue #48: Implementation guidance for browsers when a media element with controls is remoted.

- Adds a NOTE that the remote playback state should be reflected in default media controls.
- Adds a NOTE that local audio and video output for the media element should be paused.

The issue didn't discuss the disposition of text tracks (embedded in the media stream, or in `<track>` elements) so I crafted the note to refer to specifically audio and video.
