### PR TITLE
Align repo administrivia with W3C baseline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,27 @@
 ## Contributing
 
 Please refer to the group's [Work Mode](https://www.w3.org/wiki/Second_Screen/Work_Mode).
+
+Contributions to this repository are intended to become part of Recommendation-track documents governed by the
+[W3C Patent Policy](http://www.w3.org/Consortium/Patent-Policy-20040205/) and
+[Software and Document License](http://www.w3.org/Consortium/Legal/copyright-
+software). To make substantive contributions to specifications, you must either participate
+in the relevant W3C Working Group or make a non-member patent licensing commitment.
+
+If you are not the sole contributor to a contribution (pull request), please identify all 
+contributors in the pull request comment.
+
+To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
+
+```
++@github_username
+```
+
+If you added a contributor by mistake, you can remove them in a comment with:
+
+```
+-@github_username
+```
+
+If you are making a pull request on behalf of someone else but you had no part in designing the 
+feature, you can remove yourself with the above syntax.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,4 @@
+All documents in this Repository are licensed by contributors
+under the 
+[W3C Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software).
+

--- a/w3c.json
+++ b/w3c.json
@@ -1,0 +1,5 @@
+ {
+    "group":      ["74168"]
+,   "contacts":   ["tidoust"]
+,   "shortName":  "remote-playback"
+}


### PR DESCRIPTION
Add LICENSE with reference to Doc & Sw license
Complete CONTRIBUTING.md with instructions for attributions
Document owner of repo in w3c.json