### PR TITLE
Mark Anton Vayvod as former editor.

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,14 +15,15 @@
         shortName:  'remote-playback',
         editors: [
           {
-            w3cid: 68811,
-            name: 'Anton Vayvod',
-            company: 'Google',
-          },
-          {
             w3cid: 45389,
             name: 'Mounir Lamouri',
             company: 'Google',
+          },
+          {
+            w3cid: 68811,
+            name: 'Anton Vayvod',
+            company: 'Google',
+            note: 'Former Editor',
           },
         ],
         sotdAfterWGinfo: true,


### PR DESCRIPTION
Respec doesn't offer an option to declare an editor as retired semantically (see [bug](https://github.com/w3c/respec/issues/1097)), contrary to bikeshed. Marking this as a note instead.

@avayvod PTAL :)