### PR TITLE
Remove RFC terms from the note

### DIFF
--- a/index.html
+++ b/index.html
@@ -1237,22 +1237,22 @@
             <a>disconnect from a remote playback device</a>.
           </p>
           <div class="note">
-	    <p>
-	      The <a>remote playback device</a> may implement a subset
-	      of the capabilities of the playback engine of the user
-	      agent, and some <a>HTMLMediaElement</a> APIs may not make sense to use during
-              remote playback. In this case, the <a>local playback state</a> should
-	      reflect as closely as possible the actual <a>remote
-              playback state</a> after a media command that is not supported during
-	      remote playback.
-	    </p>
-	    <p>
-	      For example, after calling <code><a>fastSeek</a>()</code> while
-	      connected to a <a>remote playback device</a> that does not
-	      support it, the <code><a>seeking</a></code> attribute of the
-	      <a>HTMLMediaElement</a> should remain <code>false</code> and no
-	      <code>seeking</code> event should be fired.
-	    </p>
+            <p>
+              The <a>remote playback device</a> can implement a subset
+              of the capabilities of the playback engine of the user
+              agent, and some <a>HTMLMediaElement</a> APIs do not always
+              make sense to use during remote playback. In this case, the
+              <a>local playback state</a> is expected to reflect as closely
+              as possible the actual <a>remote playback state</a> after a
+              media command that is not supported during remote playback.
+            </p>
+            <p>
+              For example, after calling <code><a>fastSeek</a>()</code> while
+              connected to a <a>remote playback device</a> that does not
+              support it, the <code><a>seeking</a></code> attribute of the
+              <a>HTMLMediaElement</a> is expected to remain <code>false</code>
+              and no <code>seeking</code> event should be fired.
+            </p>
           </div>
         </section>
         <section>


### PR DESCRIPTION
Complements #94.

Notes should not use RFC terms since they contain informative text only. This PR replaces the RFC terms with similar informative terms.

PTAL @mfoltzgoogle @mounirlamouri


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/remote-playback/remove-rfc-terms.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/remote-playback/dc28802...e2aaf9b.html)