### PR TITLE
Adjust notes to clarify informative/normative intent

### DIFF
--- a/index.html
+++ b/index.html
@@ -806,7 +806,7 @@
             </p>
             <div class="note">
               To avoid leaking information that could fingerprint the user, the
-              user agent SHOULD NOT assign a <var>callbackId</var> that uses any
+              user agent should not assign a <var>callbackId</var> that uses any
               persistent information from the browser profile or a <a>remote
               playback device</a>.
             </div>
@@ -1052,7 +1052,7 @@
           </ol>
           <div class="note">
             The details of implementing the UI and device selection are left to
-            the user agent; for example it MAY show the user a dialog and allow
+            the user agent; for example it may show the user a dialog and allow
             the user to select an available device (<em>granting
             permission</em>), or cancel the selection (<em>denying
             permission</em>).
@@ -1166,6 +1166,18 @@
               </ol>
             </li>
           </ol>
+          <p>
+            The user agent SHOULD pause local audio and video output of the
+            media element while the <a>remote playback state</a>
+            is <a data-link-for="RemotePlaybackState">connected</a>.
+          </p>
+          <p>
+            If the user agent is <a>exposing a user interface to the user</a>
+            for the media element (i.e., using default controls), the user agent
+            SHOULD convey the fact that the <a>remote playback state</a>
+            is <a data-link-for="RemotePlaybackState">connected</a> through an
+            icon or other means.
+          </p>
           <div class="note">
             The mechanism that is used to connect the user agent with the
             <a>remote playback device</a> and play the <a>remote playback
@@ -1175,18 +1187,6 @@
             playback device and receiving media playback state in order to keep
             the <a>media element state</a> and <a>remote playback state</a> in
             sync (unless <a>media mirroring</a> is used).
-          </div>
-          <div class="note">
-            The user agent SHOULD pause local audio and video output of the
-            media element while the <a>remote playback state</a>
-            is <a data-link-for="RemotePlaybackState">connected</a>.
-          </div>
-          <div class="note">
-            If the user agent is <a>exposing a user interface to the user</a>
-            for the media element (i.e., using default controls), the user agent
-            SHOULD convey the fact that the <a>remote playback state</a>
-            is <a data-link-for="RemotePlaybackState">connected</a> through an
-            icon or other means.
           </div>
         </section>
         <section>
@@ -1319,7 +1319,7 @@
           <div class="note">
             If the remote playback device is abruptly disconnected during
             playback (for example, by power loss or a network disconnection),
-            the user agent SHOULD run the steps to <a>monitor the list of
+            the user agent should run the steps to <a>monitor the list of
             available remote playback devices</a> before the steps
             to <a>disconnect from a remote playback device</a>.  This allows
             callbacks in the <a>set of availability callbacks</a> to be invoked

--- a/index.html
+++ b/index.html
@@ -639,15 +639,15 @@
               devices.
             </p>
             <p class="note">
-              User agents SHOULD NOT <a>monitor the list of available remote
-              playback devices</a> when possible, to satisfy the <a href=
+              The user agent is expected not to <a>monitor the list of available
+              remote playback devices</a> when possible, to satisfy the <a href=
               "https://github.com/w3c/remote-playback/blob/gh-pages/use-cases.md#power-saving-friendly">
               power saving non-functional requirement</a>. For example, the
-              <a>user agent</a> MAY not run the monitoring algorithm when the
-              <a>global set of availability callbacks</a> is empty, when every
-              page that has <a data-lt="media element">media elements</a> with
-              non-empty <a>set of availability callbacks</a> is in the
-              background.
+              <a>user agent</a> might choose not to run the monitoring
+              algorithm when the <a>global set of availability callbacks</a> is
+              empty, when every page that has <a data-lt="media element">media
+              elements</a> with non-empty <a>set of availability callbacks</a>
+              is in the background.
             </p>
             <p>
               Some <a>remote playback devices</a> may only be able to play a

--- a/index.html
+++ b/index.html
@@ -1308,6 +1308,16 @@
               </ol>
             </li>
           </ol>
+          <p>
+            If the remote playback device is abruptly disconnected during
+            playback (for example, by power loss or a network disconnection),
+            the user agent SHOULD run the steps to <a>monitor the list of
+            available remote playback devices</a> before the steps to
+            <a>disconnect from a remote playback device</a>.  This allows
+            callbacks in the <a>set of availability callbacks</a> to be invoked
+            before the <a>disconnect</a> event is fired, so the page can update
+            itself to show resumption of playback is not possible.
+          </p>
           <div class="note">
             The remote playback device might not actually stop playback of the
             media when requested by the user agent since it's implementation
@@ -1315,16 +1325,6 @@
             stopping remote playback merely means the user agent literally only
             disconnecting from the remote playback device and the <a>media
             element</a> switching to the <code>disconnected</code> state.
-          </div>
-          <div class="note">
-            If the remote playback device is abruptly disconnected during
-            playback (for example, by power loss or a network disconnection),
-            the user agent is expected to run the steps to <a>monitor the list
-            of available remote playback devices</a> before the steps
-            to <a>disconnect from a remote playback device</a>.  This allows
-            callbacks in the <a>set of availability callbacks</a> to be invoked
-            before the <a>disconnect</a> event is fired, so the page can update
-            itself to show resumption of playback is not possible.
           </div>
         </section>
         <section>

--- a/index.html
+++ b/index.html
@@ -806,9 +806,9 @@
             </p>
             <div class="note">
               To avoid leaking information that could fingerprint the user, the
-              user agent should not assign a <var>callbackId</var> that uses any
-              persistent information from the browser profile or a <a>remote
-              playback device</a>.
+              user agent is expected not to assign a <var>callbackId</var> that
+              uses any persistent information from the browser profile or a
+              <a>remote playback device</a>.
             </div>
           </section>
           <section>
@@ -1052,7 +1052,7 @@
           </ol>
           <div class="note">
             The details of implementing the UI and device selection are left to
-            the user agent; for example it may show the user a dialog and allow
+            the user agent; for example it can show the user a dialog and allow
             the user to select an available device (<em>granting
             permission</em>), or cancel the selection (<em>denying
             permission</em>).
@@ -1319,8 +1319,8 @@
           <div class="note">
             If the remote playback device is abruptly disconnected during
             playback (for example, by power loss or a network disconnection),
-            the user agent should run the steps to <a>monitor the list of
-            available remote playback devices</a> before the steps
+            the user agent is expected to run the steps to <a>monitor the list
+            of available remote playback devices</a> before the steps
             to <a>disconnect from a remote playback device</a>.  This allows
             callbacks in the <a>set of availability callbacks</a> to be invoked
             before the <a>disconnect</a> event is fired, so the page can update


### PR DESCRIPTION
This update updates the notes that contained normative statements as suggested in #101.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tidoust/remote-playback/issue-101-notes.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/remote-playback/6cf10e7...tidoust:337e83d.html)