### PR TITLE
Add disableRemotePlayback definition.

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,7 +326,8 @@
         [[!WEBIDL]].
       </p>
       <p>
-        The interface <dfn>PresentationRequest</dfn> is defined in [[PRESENTATION-API]].
+        The interface <dfn><code>PresentationRequest</code></dfn> is defined in
+        [[PRESENTATION-API]].
       </p>
       <p>
         The term <dfn><a href=
@@ -790,8 +791,9 @@
                 </ol>
               </li>
               <li>Let <var>callbackId</var> be a positive integer unique among
-                all the <var>callbackIds</var> previously returned by these steps
-                in the <a>browsing context</a> of the <a>media element</a>.
+                all the <var>callbackIds</var> previously returned by these
+                steps in the <a>browsing context</a> of the <a>media
+                element</a>.
               </li>
               <li>Create a tuple <em>(<var>callbackId</var>,
               <var>callback</var>)</em> and add it to the <a>set of
@@ -986,8 +988,8 @@
             <var>promise</var> with an <a>InvalidAccessError</a> exception and
             abort these steps.
             </li>
-            <li>OPTIONALLY, if the <a>user agent</a> knows a priori that remote playback
-            of this particular <a>media element</a> is not feasible
+            <li>OPTIONALLY, if the <a>user agent</a> knows a priori that remote
+            playback of this particular <a>media element</a> is not feasible
             (independent of the current
             <code><a data-link-for="RemotePlayback">state</a></code> or
             the <a>list of available remote playback devices</a>),
@@ -1425,7 +1427,8 @@
         </p>
         <section>
           <h4>
-            The <code><dfn data-dfn-for='HTMLMediaElement'>disableRemotePlayback</dfn></code> attribute
+            The <code><dfn data-dfn-for='HTMLMediaElement'>disableRemotePlayback</dfn></code>
+            attribute
           </h4>
           <p>
             Some pages may wish to disable remote playback of a media element;

--- a/index.html
+++ b/index.html
@@ -1431,15 +1431,15 @@
             Some pages may wish to disable remote playback of a media element;
             for example, they may prefer to use a <a>PresentationRequest</a> to
             present a complete document on a presentation screen.  To support
-            this use case, a new <code>disableRemotePlayback</code> is added to
-            the list of content attributes for <code>audio</code>
+            this use case, a new <code>disableRemotePlayback</code> attribute is
+            added to the list of content attributes for <code>audio</code>
             and <code>video</code> elements.
           </p>
           <p>
             A corresponding
             <a data-link-for='HTMLMediaElement'>disableRemotePlayback</a>
-            IDL attribute which reflects the value each element’s
-            <code>disableRemotePlaback</code> content attribute is added to
+            IDL attribute which reflects the value of each element’s
+            <code>disableRemotePlayback</code> content attribute is added to
             the <code>HTMLMediaElement</code> interface.
             The <a data-link-for='HTMLMediaElement'>disableRemotePlayback</a>
             IDL attribute MUST <a>reflect</a> the content attribute of the same

--- a/index.html
+++ b/index.html
@@ -1436,12 +1436,14 @@
             and <code>video</code> elements.
           </p>
           <p>
-            A corresponding <a data-link-for='HTMLMediaElement'>disableRemotePlayback</a>
+            A corresponding
+            <a data-link-for='HTMLMediaElement'>disableRemotePlayback</a>
             IDL attribute which reflects the value each element’s
             <code>disableRemotePlaback</code> content attribute is added to
             the <code>HTMLMediaElement</code> interface.
             The <a data-link-for='HTMLMediaElement'>disableRemotePlayback</a>
-            IDL attribute MUST <a>reflect</a> the content attribute of the same name.
+            IDL attribute MUST <a>reflect</a> the content attribute of the same
+            name.
           </p>
         </section>
         <section>

--- a/index.html
+++ b/index.html
@@ -308,7 +308,8 @@
           'https://html.spec.whatwg.org/multipage/infrastructure.html#concept-event-fire'>
           firing an event</a></dfn> and <dfn><a href=
           'https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel'>
-          in parallel</a></dfn>,
+              in parallel</a></dfn>,
+          <dfn><a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributes">reflect</a></dfn>,
         </li>
         <li>
           <dfn><a href=
@@ -323,6 +324,9 @@
       <p>
         The term <dfn>throw</dfn> in this specification is used as defined in
         [[!WEBIDL]].
+      </p>
+      <p>
+        The interface <dfn>PresentationRequest</dfn> is defined in [[PRESENTATION-API]].
       </p>
       <p>
         The term <dfn><a href=
@@ -1405,7 +1409,7 @@
       </section>
       <section>
         <h3>
-          Extension to the <code><a>HTMLMediaElement</a></code>
+          Extensions to <code><a>HTMLMediaElement</a></code>
         </h3>
         <pre class='idl'>
           partial interface HTMLMediaElement {
@@ -1419,10 +1423,27 @@
           return the <a>RemotePlayback</a> instance associated with the
           <a>media element</a>.
         </p>
-        <p>
-          The <dfn data-dfn-for='HTMLMediaElement'>disableRemotePlayback</dfn>
-          IDL attribute MUST reflect the content attribute of the same name.
-        </p>
+        <section>
+          <h4>
+            The <code><dfn data-dfn-for='HTMLMediaElement'>disableRemotePlayback</dfn></code> attribute
+          </h4>
+          <p>
+            Some pages may wish to disable remote playback of a media element;
+            for example, they may prefer to use a <a>PresentationRequest</a> to
+            present a complete document on a presentation screen.  To support
+            this use case, a new <code>disableRemotePlayback</code> is added to
+            the list of content attributes for <code>audio</code>
+            and <code>video</code> elements.
+          </p>
+          <p>
+            A corresponding <a data-link-for='HTMLMediaElement'>disableRemotePlayback</a>
+            IDL attribute which reflects the value each element’s
+            <code>disableRemotePlaback</code> content attribute is added to
+            the <code>HTMLMediaElement</code> interface.
+            The <a data-link-for='HTMLMediaElement'>disableRemotePlayback</a>
+            IDL attribute MUST <a>reflect</a> the content attribute of the same name.
+          </p>
+        </section>
         <section>
           <h4>
             Disabling remote playback
@@ -1431,7 +1452,7 @@
             If the <a data-link-for=
             'HTMLMediaElement'>disableRemotePlayback</a> attribute is present
             on the <a>media element</a>, the <a>user agent</a> MUST NOT play
-            the media remotely or present any UI to do so.
+            the media element remotely or present any UI to do so.
           </p>
           <p>
             When the <a data-link-for=
@@ -1452,7 +1473,6 @@
             the media element is connected or connecting to.
             </li>
           </ol>
-          <p></p>
         </section>
       </section>
     </section>


### PR DESCRIPTION
Addresses Issue #105: Add explicit text to define the disableRemotePlayback content attribute.

This adds a disableRemotePlayback attribute definition styled after the one for subresource integrity.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/mfoltzgoogle/remote-playback/issue-105-remote-playback.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/remote-playback/c9617ae...mfoltzgoogle:82be55f.html)