### PR TITLE
'Potentially secure' is now 'potentially trustworthy origin'

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,8 +331,8 @@
       </p>
       <p>
         The term <dfn><a href=
-        "https://www.w3.org/TR/mixed-content/#potentially-secure-origin">potentially
-        secure</a></dfn> is defined in [[!MIXED-CONTENT]].
+        "https://www.w3.org/TR/secure-contexts/#potentially-trustworthy-origin">
+        potentially trustworthy origin</a></dfn> is defined in [[!SECURE-CONTEXTS]].
       </p>
       <p>
         The following exception names are defined by [[!WEBIDL]] and used by
@@ -1544,8 +1544,8 @@
             </p>
             <p>
               Showing the origin that will be presented will help the user know
-              if that content is from an <a>potentially secure</a> (e.g.,
-              <code>https:</code>) origin, and corresponds to a known or
+              if that content is from a <a>potentially trustworthy origin</a>
+              (e.g., <code>https:</code>), and corresponds to a known or
               expected site.
             </p>
           </dd>


### PR DESCRIPTION
Definition migrated from [MIXED-CONTENT] to [SECURE-CONTEXTS].


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/remote-playback/potentially-secure.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/remote-playback/df201f5...dcfd5b8.html)