### PR TITLE
Addresses Issue 41

### DIFF
--- a/index.html
+++ b/index.html
@@ -1259,8 +1259,8 @@
             When the <a data-link-for="RemotePlayback">state</a> of
             a <a>RemotePlayback</a> object
             is <a data-link-for="RemotePlaybackState">connected</a>, the
-            following conditions relate the <a>local playback
-            state</a>, <a>media element state</a>, and <a>remote playback
+            following conditions relate the <a>local playback state</a>,
+            the <a>media element state</a>, and the <a>remote playback
             state</a>:
           </p>
           <dl>
@@ -1282,7 +1282,7 @@
               The <a>user agent</a> MUST process all updates of the
               <a>remote playback state</a> received from the <a>remote playback
                 device</a> and update the <a>local playback state</a> of the
-              media element.
+              media element accordingly.
             </dd>
           </dl>
           <p>

--- a/index.html
+++ b/index.html
@@ -1256,20 +1256,35 @@
             device</a> is established.
           </p>
           <p>
-            In particular, as soon as the <a data-link-for=
-            "RemotePlayback">state</a> of a <a>RemotePlayback</a> object has
-            changed to <a data-link-for="RemotePlaybackState">connected</a>,
-            the <a>user agent</a> MUST send all the media commands issued on
-            the <a>HTMLMediaElement</a> object with which the
-            <a>RemotePlayback</a> object is associated to the <a>remote
-            playback device</a> in order to change the <a>remote playback
-            state</a> vs the <a>local playback state</a>.
+            When the <a data-link-for="RemotePlayback">state</a> of
+            a <a>RemotePlayback</a> object
+            is <a data-link-for="RemotePlaybackState">connected</a>, the
+            following conditions relate the <a>local playback
+            state</a>, <a>media element state</a>, and <a>remote playback
+            state</a>:
           </p>
-          <p>
-            Similarly, the <a>user agent</a> MUST reflect all updates of the
-            <a>remote playback state</a> received from the <a>remote playback
-            device</a> on the <a>media element state</a>.
-          </p>
+          <dl>
+            <dd>
+              The <a>user agent</a> MUST send all media commands issued on the
+              associated <a>HTMLMediaElement</a> object to the <a>remote playback
+                device</a> in order to change its <a>remote playback state</a>;
+            </dd>
+            <dd>
+              The <a>remote playback device</a> SHOULD implement all media
+              commands sent by the <a>user agent</a>;
+            </dd>
+            <dd>
+              The <a>remote playback device</a> SHOULD send updates of
+              the <a>remote playback state</a> to the <a>user agent</a> that
+              affect any attribute exposed through the <a>media element
+              state</a>;
+            <dd>
+              The <a>user agent</a> MUST process all updates of the
+              <a>remote playback state</a> received from the <a>remote playback
+                device</a> and update the <a>local playback state</a> of the
+              media element.
+            </dd>
+          </dl>
           <p>
             If sending any command fails, the <a>user agent</a> MAY
             <a>disconnect from a remote playback device</a>.


### PR DESCRIPTION
Addresses Issue #41: Guidance for HTMLMediaElement, HTMLAudioElement, HTMLVideoElement behaviors during remoting.

This clarifies the relationship between the local playback state and the remote playback state.

It adds conditions that the remote playback device should implement media commands and send updates, but does not further specify which commands/state at this time.

This follows an action from TPAC:
https://www.w3.org/2017/11/06-webscreens-minutes.html#x03


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mfoltzgoogle/remote-playback/pull/112.html" title="Last updated on Dec 5, 2017, 12:09 AM GMT (e662dd7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/remote-playback/112/22725db...mfoltzgoogle:e662dd7.html" title="Last updated on Dec 5, 2017, 12:09 AM GMT (e662dd7)">Diff</a>