### PR TITLE
Adds informative note about UI during remote playback.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1220,6 +1220,12 @@
             <code>Accept-Language</code> header it sends to fetch media
             resources.
           </div>
+          <div class="note">
+            The user agent should not render output from the media element while
+            it is in a <a data-link-for="RemotePlaybackState">connected</a>
+            state and its content is being rendered on a <a>remote playback
+              device</a>.
+          </div>
         </section>
         <section>
           <h4>


### PR DESCRIPTION
PTAL @mounirlamouri 

This addresses (I think) the discussion during TPAC of Issue #46: Should rendering behavior of the remote-d media element be specified?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mfoltzgoogle/remote-playback/pull/113.html" title="Last updated on Jan 10, 2018, 10:22 PM GMT (1d9c2b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/remote-playback/113/e1da486...mfoltzgoogle:1d9c2b0.html" title="Last updated on Jan 10, 2018, 10:22 PM GMT (1d9c2b0)">Diff</a>