### PR TITLE
Addresses Issue #114

### DIFF
--- a/index.html
+++ b/index.html
@@ -1234,22 +1234,32 @@
           <p>
             A user agent MAY support <a data-lt=
             "establish a connection with the remote playback device">connecting
-            to a remote playback device</a> from the browser, e.g. by including
-            appropriate controls to <a data-lt=
+              to a remote playback device</a> from the browser. This can be done by
+            adding appropriate media controls to <a data-lt=
             "expose a user interface to the user">the user interface that is
-            exposed to the user</a>. This feature is known as <dfn>browser
+              exposed to the user</a>, or when the user activates system-wide
+            mirroring of the display.  This feature is known as <dfn>browser
             initiated remote playback</dfn>. A <a>user agent</a> that supports
             <a>browser initiated remote playback</a> SHOULD initiate the remote
             playback only when the user has expressed an intention to do so via
             a user gesture, for example by clicking a button in the browser.
           </p>
           <p>
-            If the user agent supports <a>browser initiated remote
-            playback</a>, it MUST support the <a data-link-for=
-            "RemotePlayback">state</a> attribute and the corresponding events
-            by following the algorithms to <a>establish a connection with the
-            remote playback device</a> and <a>disconnect from a remote playback
-            device</a>.
+            If the user agent supports <a>browser initiated remote playback</a>,
+            the <a data-link-for="RemotePlayback">state</a> attribute MUST
+            reflect the current state of the connection to the <a>remote
+            playback device</a>.  When the browser initiates or terminates
+            remote playback, it MUST fire the corresponding events by following
+            the algorithms to <a>establish a connection with the remote playback
+            device</a> and <a>disconnect from a remote playback device</a>.
+          </p>
+          <p>
+            If the <a data-lt="browser initiated remote playback">browser will
+            initiate remote playback</a> on a newly created media element,
+            it SHOULD initialize the value of its <a data-link-for="RemotePlayback">
+            state</a> attribute to <a data-link-for="RemotePlaybackState">
+            connecting</a> and then follow the steps to <a>establish a connection
+            with the remote playback device</a>.
           </p>
         </section>
         <section>

--- a/index.html
+++ b/index.html
@@ -1014,13 +1014,20 @@
             reject <var>promise</var> with a <a>NotFoundError</a> exception and
             abort all remaining steps.
             </li>
-            <li>Request user a permission to <dfn>change remote playback
+            <li>Request user permission to <dfn>change remote playback
             state</dfn>.
               <div class="note">
-                An example would be showing UI that allows the user to pick a
-                <a>remote playback device</a> or switch between the local or
-                remote playback devices or has a button to <a>disconnect from
-                a remote playback device</a>.
+                An example UI to request permission would allow the user to
+                pick a new <a>remote playback device</a>, switch between local
+                or remote playback devices, or <a>disconnect from a remote
+                playback device</a>.
+              </div>
+              <div class="note">
+                The user may have already selected a <a>remote playback
+                device</a> for a related purpose, for example, to mirror the
+                contents of the display or the current page.  In that case, the
+                user agent may choose to skip the UI to select a device and
+                proceed immediately to the next step.
               </div>
             </li>
             <li>If the user picked a <a>remote playback device</a>


### PR DESCRIPTION
Clarifies how remote playback state should be handled when the user is mirroring the display, which the UA can interpret as a request to initiate remote playback on video elements, either when they are created or when they are taken fullscreen.

Addresses Issue #114: Compatibility of Remote Playback API with AirPlay mirroring.

CC @mounirlamouri @jernoble


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mfoltzgoogle/remote-playback/pull/115.html" title="Last updated on Feb 14, 2018, 11:59 PM GMT (f295257)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/remote-playback/115/dc6667b...mfoltzgoogle:f295257.html" title="Last updated on Feb 14, 2018, 11:59 PM GMT (f295257)">Diff</a>