### PR TITLE
Add a remoting buffer state attribute to RemotePlayback

### DIFF
--- a/index.html
+++ b/index.html
@@ -534,6 +534,9 @@
             attribute EventHandler onconnect;
             attribute EventHandler ondisconnect;
 
+            readonly attribute RemotingBufferState remotingBufferState;
+            attribute EventHandler onremotingbufferstatechanged;
+
             Promise&lt;void&gt; prompt();
           };
 
@@ -541,6 +544,13 @@
             "connecting",
             "connected",
             "disconnected"
+          };
+
+          enum RemotingBufferState {
+            "insufficient-data",
+            "enough-data",
+            "too-much-data",
+            "not-remoting"
           };
 
           callback RemotePlaybackAvailabilityCallback = void(boolean available);
@@ -553,6 +563,10 @@
         <p>
           A <dfn>RemotePlaybackState</dfn> enumeration represents the state of
           connection to some <a>remote playback device</a>.
+        </p>
+        <p>
+          A <dfn>RemotingBufferState</dfn> enumeration represents the buffer
+          state of the remote media in <a>media remoting</a> mode.
         </p>
         <p>
           A <dfn>RemotePlaybackAvailabilityCallback</dfn> represents the
@@ -1136,6 +1150,40 @@
         </section>
         <section>
           <h4>
+            The <code><a data-link-for="RemotePlayback">remotingBufferState</a>
+            </code> attribute
+          </h4>
+          <p>
+            The <dfn data-dfn-for="RemotePlayback"><code>remotingBufferState
+            </code></dfn> attribute represents the buffer state of the remote
+            media in <a>media remoting</a> mode. It can take one of the values
+            of <a>RemotingBufferState</a> depending on the connection state:
+          </p>
+          <ul data-dfn-for="RemotingBufferState">
+            <li>
+              <dfn>insufficient-data</dfn> means that the receiving user agent
+              has buffered media for such a short duration that it is likely to
+              need to pause playback to wait for more data soon. The logic to
+              determine this state is up to the user agent implementation.
+            </li>
+            <li>
+              <dfn>enough-data</dfn> means that the receiving user agent has
+              buffered an amount of data that is between insufficient and too
+              much.
+            </li>
+            <li>
+              <dfn>too-much-data</dfn> means that there is more media being sent
+              by the controlling user agent than what can be handled, either by
+              the receiving user agent's buffer, or the network.
+            </li>
+            <li>
+              <dfn>not-remoting</dfn> means that the remote playback is in
+              <a>media flinging</a> mode, or is disconnected or connecting.
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h4>
             Establishing a connection with a remote playback device
           </h4>
           <p>
@@ -1444,6 +1492,14 @@
                 </td>
                 <td>
                   <dfn><code>disconnect</code></dfn>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <dfn><code>onremotingbufferstatechanged</code></dfn>
+                </td>
+                <td>
+                  <dfn><code>remotingbufferstatechanged</code></dfn>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
This PR proposes to add a remoting buffer state attribute to RemotePlayback, which will indicate the remote buffer state when using MSE / media remoting mode (as opposed to media/URL flinging).

Here is sample code showing how RemotePlayback may interact with MSE using the new enum:
```javascript
const video = document.querySelector('#my-video');
const mediaSource = new MediaSource();
let sourceBuffer;
let isBufferingSegments = false;
mediaSource.addEventListener('sourceopen', onMediaSourceOpen);
video.src = window.URL.createObjectURL(mediaSource);
video.remote.addEventListener('remotingstatechanged', onRemotingStateChanged);

function onRemotingStateChanged() {
  switch (video.remote.remotingBufferState) {
    case 'insufficient-data':
      lowerResolution();
      startBufferingSegments();
      break;
    case 'enough-data':
      startBufferingSegments();
      break;
    case 'too-much-data':
    case 'not-remoting':
      stopBufferingSegments();
      break;
  }
}

async function onMediaSourceOpen() {
  sourceBuffer = mediaSource.addSourceBuffer('video/mp4; codecs="avc1.4d401f"');
  await startBufferingSegments();
  video.play();
}

async function startBufferingSegments() {
  if (isBufferingSegments) {
    return;
  }
  isBufferingSegments = true;
  sourceBuffer.addEventListener('updateend', bufferNextSegment);
  await bufferNextSegment();
}

function stopBufferingSegments() {
  if (!isBufferingSegments) {
    return;
  }
  isBufferingSegments = false;
  sourceBuffer.removeEventListener('updateend', bufferNextSegment);
}

async function bufferNextSegment() {
  const videoChunk = await getNextVideoChunk();
  sourceBuffer.appendBuffer(new Uint8Array(videoChunk));
}

async function getNextVideoChunk() {
  // Fetches and returns a video chunk.
}

```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/takumif/remote-playback/pull/126.html" title="Last updated on Sep 4, 2019, 5:42 PM UTC (f590655)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/remote-playback/126/1d359bc...takumif:f590655.html" title="Last updated on Sep 4, 2019, 5:42 PM UTC (f590655)">Diff</a>