### PR TITLE
Fix ReSpec HTMLMediaElement dfn error

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,8 +262,7 @@
       <ul>
         <li>
           <dfn><a href=
-          'https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement'>
-          HTMLMediaElement</a></dfn>, <dfn><a href=
+          'https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement'>HTMLMediaElement</a></dfn>, <dfn><a href=
           'https://html.spec.whatwg.org/multipage/embedded-content.html#media-element'>
           media element</a></dfn>, <dfn data-lt=
           "resource selection algorithm"><a href=


### PR DESCRIPTION
A line break in text content breaks ReSpec definitions.

Error:
Couldn't match "HTMLMediaElement" to anything in the document or
in any other document cited in this specification: webidl.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/remote-playback/pull/127.html" title="Last updated on Oct 10, 2019, 7:39 AM UTC (a555a4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/remote-playback/127/1d359bc...a555a4d.html" title="Last updated on Oct 10, 2019, 7:39 AM UTC (a555a4d)">Diff</a>