### PR TITLE
Editorial: simplify spec by using new features in ReSpec

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,10 +259,10 @@
       <p>
         This section shows code examples that highlight the usage of the main
         features of the Remote Playback API. In these examples,
-        <code>player.html</code> implements the player page controlling the
-        remote playback and <code>media.ext</code> is the media file to be
+        `player.html` implements the player page controlling the
+        remote playback and `media.ext` is the media file to be
         played remotely. Both the page and the media are served from the domain
-        <code>https://example.org</code>. Please refer to the comments in the
+        `https://example.org`. Please refer to the comments in the
         code examples for further details.
       </p>
       <section>
@@ -385,7 +385,7 @@
           for convenience.
         </p>
         <div class="example">
-          For example, the <code>paused</code> attribute or the pause/resume
+          For example, the `paused` attribute or the pause/resume
           button reflecting that state on the default controls of the media
           element would be a part of <a>media element state</a>.
         </div>
@@ -403,7 +403,7 @@
         <p class="note">
           For a good user experience it is important that the <a>media element
           state</a> doesn't change unexpectedly when the
-          <code><a data-link-for="RemotePlayback">state</a></code> changes. It
+          <a data-link-for="RemotePlayback">`state`</a> changes. It
           is also important that <a>remote playback state</a> is in sync with
           the <a>media element state</a> so when the media is paused on the
           <a>remote playback device</a> it looks paused to both the user and
@@ -417,7 +417,7 @@
       </section>
       <section>
         <h3>
-          <code><a>RemotePlayback</a></code> interface
+          <a>`RemotePlayback`</a> interface
         </h3>
         <pre class='idl'>
           [Exposed=Window]
@@ -460,14 +460,14 @@
             Observing remote playback device availability
           </h4>
           <p>
-            A <a><code>RemotePlaybackAvailabilityCallback</code></a> is the way
+            A <a>`RemotePlaybackAvailabilityCallback`</a> is the way
             for the page to obtain the <dfn>remote playback device
             availability</dfn> for the corresponding <a>media element</a>. If
             the user agent can <a>monitor the list of available remote playback
             devices</a> in the background (without a pending request to
-            <code><a>prompt</a>()</code>), the <code><a>RemotePlaybackAvailabilityCallback</a></code>
-            behavior defined below MUST be implemented by the user agent. Otherwise, the
-            promise returned by <code><a>watchAvailability</a>()</code> MUST be rejected
+            <a>`prompt`</a>`()`), the <a>`RemotePlaybackAvailabilityCallback`</a> behavior
+            defined below MUST be implemented by the user agent. Otherwise, the
+            promise returned by <a>`watchAvailability`</a>`()` MUST be rejected
             with {{NotSupportedError}}.
           </p>
           <section>
@@ -477,21 +477,20 @@
             <p>
               The <a>user agent</a> MUST keep track of the <dfn>set of
               availability callbacks</dfn> registered with each <a>media
-              element</a> through the <code><a>watchAvailability</a>()</code> method. The
+              element</a> through the <a>`watchAvailability`</a>`()` method. The
               <a>set of availability callbacks</a> for each
               <a>RemotePlayback</a> object is represented as a set of tuples
-              <em>(<var>callbackId</var>, <var>callback</var>)</em>, initially
-              empty, where:
+              <em>(|callbackId:long|, |callback:RemotePlaybackAvailabilityCallback|)</em>,
+              initially empty, where:
             </p>
             <ol>
               <li>
-                <var>callbackId</var> is a positive integer unique among all ids
-                returned by <code><a>watchAvailability</a>()</code>
+                |callbackId| is a positive integer unique among all ids
+                returned by <a>`watchAvailability`</a>`()`
                 in a given <a>browsing context</a>;
               </li>
               <li>
-                <var>callback</var> is a
-                <a>RemotePlaybackAvailabilityCallback</a> object.
+                |callback| is a <a>RemotePlaybackAvailabilityCallback</a> object.
               </li>
             </ol>
             <p>
@@ -528,7 +527,7 @@
               <a>monitor the list of available remote playback devices</a>
               continuously, for example, because of platform or power
               consumption restrictions. In this case the promise returned by
-              <code><a>watchAvailability</a>()</code> MUST be rejected
+              <a>`watchAvailability`</a>`()` MUST be rejected
               with {{NotSupportedError}}, the <a>global set of availability
               callbacks</a> will be empty and the algorithm to <a>monitor the
               list of available remote playback devices</a> will only run as
@@ -602,9 +601,9 @@
               devices</a> is empty or none of them is compatible with any
               source from <a>availability sources set</a> for the <a>media
               element</a>. The remote playback is said to be
-              <dfn>available</dfn> otherwise. A <code>boolean</code> set to
-              <code>false</code> if the remote playback is <a>unavailable</a>
-              for the <a>media element</a> or <code>true</code> if it is
+              <dfn>available</dfn> otherwise. A `boolean` set to
+              `false` if the remote playback is <a>unavailable</a>
+              for the <a>media element</a> or `true` if it is
               <a>available</a> is called <dfn>availability</dfn> for the
               <a>media element</a>.
             </p>
@@ -614,10 +613,10 @@
               monitoring the list of available remote playback devices</a>
               (for example by a user control or for power saving), it SHOULD
               invoke all callbacks in the <a>global set of availability
-              callbacks</a> with <code>false</code> so that pages can update
+              callbacks</a> with `false` so that pages can update
               their user experience appropriately.  It SHOULD also set
               the <a>availability</a> value for all <a>media elements</a>
-              to <code>false</code> so that availability information can
+              to `false` so that availability information can
               be propagated correctly if the user agent later resumes
               <a data-lt="monitor the list of available remote playback devices">
               monitoring the list of available remote playback devices</a>.
@@ -629,7 +628,7 @@
               information
             </h5>
             <p>
-              When the <code><dfn>watchAvailability</dfn>()</code> method is
+              When the <dfn>`watchAvailability`</dfn>`()` method is
               called, the user agent MUST run the following steps:
             </p>
             <dl>
@@ -637,87 +636,98 @@
                 Input
               </dt>
               <dd>
-                <var>callback</var>, the callback that will get fired with
-                availability information.
+                |callback:RemotePlaybackAvailabilityCallback|, the callback that
+                will get fired with availability information.
               </dd>
               <dt>
                 Output
               </dt>
               <dd>
-                <var>promise</var>, a promise.
+                |promise:Promise|, a {{Promise}}.
               </dd>
             </dl>
             <ol>
-              <li>Let <var>promise</var> be a new promise.
+              <li>
+                Let |promise| be a new {{Promise}}.
               </li>
-              <li>Return <var>promise</var>, and run the following steps below:
+              <li>
+                Return |promise|, and run the following steps below:
               </li>
-              <li>If the <a data-link-for=
-              "HTMLMediaElement">disableRemotePlayback</a> attribute is present
-              for the <a>media element</a>, reject the <var>promise</var> with
-              {{InvalidStateError}} and abort all the remaining steps.
+              <li>
+                If the <a data-link-for="HTMLMediaElement">disableRemotePlayback</a>
+                attribute is present for the <a>media element</a>, reject the |promise|
+                with {{InvalidStateError}} and abort all the remaining steps.
               </li>
-              <li>If the user agent is unable to <a>monitor the list of
-              available remote playback devices</a> for the entire lifetime of
-              the <a>browsing context</a> (for instance, because the user has
-              disabled this feature), then run the following steps <a>in parallel</a>:
+              <li>
+                If the user agent is unable to <a>monitor the list of
+                available remote playback devices</a> for the entire lifetime of
+                the <a>browsing context</a> (for instance, because the user has
+                disabled this feature), then run the following steps <a>in parallel</a>:
                 <ol>
-                  <li>Fulfill <var>promise</var>.
+                  <li>
+                    Fulfill |promise|.
                   </li>
                   <li>
-                    <a>Queue a task</a> to invoke the <var>callback</var> with
-                    <code>false</code> as its argument.
+                    <a>Queue a task</a> to invoke the |callback| with
+                    `false` as its argument.
                   </li>
-                  <li>Abort all remaining steps.
+                  <li>
+                    Abort all remaining steps.
                   </li>
                 </ol>
               </li>
-              <li>If the user agent is unable to continuously <a>monitor the
-              list of available remote playback devices</a> but can do it for a
-              short period of time when <a data-lt="initiate remote playback">
-              initiating remote playback</a>, then:
+              <li>
+                If the user agent is unable to continuously <a>monitor the
+                list of available remote playback devices</a> but can do it for a
+                short period of time when <a data-lt="initiate remote playback">
+                initiating remote playback</a>, then:
                 <ol>
-                  <li>Reject <var>promise</var> with a {{NotSupportedError}}
-                  exception.
+                  <li>
+                    Reject |promise| with a {{NotSupportedError}} exception.
                   </li>
-                  <li>Abort all remaining steps.
+                  <li>
+                    Abort all remaining steps.
                   </li>
                 </ol>
               </li>
-              <li>Let <var>callbackId</var> be a positive integer unique among
-                all the <var>callbackIds</var> previously returned by these
+              <li>
+                Let |callbackId:long| be a positive integer unique among
+                all the |callbackIds| previously returned by these
                 steps in the <a>browsing context</a> of the <a>media
                 element</a>.
               </li>
-              <li>Create a tuple <em>(<var>callbackId</var>,
-              <var>callback</var>)</em> and add it to the <a>set of
-              availability callbacks</a> for this <a>media element</a>.
+              <li>
+                Create a tuple <em>(|callbackId|, |callback|)</em> and
+                add it to the <a>set of availability callbacks</a>
+                for this <a>media element</a>.
               </li>
-              <li>Fulfill <var>promise</var> with the <var>callbackId</var> and
-              run the following steps <a>in parallel</a>:
+              <li>
+                Fulfill |promise| with the |callbackId| and
+                run the following steps <a>in parallel</a>:
                 <ol>
                   <li>
-                    <a>Queue a task</a> to invoke the <var>callback</var> with
+                    <a>Queue a task</a> to invoke the |callback| with
                     the current <a>availability</a> for the <a>media
                     element</a>.
                   </li>
-                  <li>If the <a>user agent</a> is not <a data-lt=
-                  "monitor the list of available remote playback devices">monitoring
-                  the list of available remote playback devices</a>, run the
-                  algorithm to <a>monitor the list of available remote playback
-                  devices</a>.
+                  <li>
+                    If the <a>user agent</a> is not <a data-lt=
+                    "monitor the list of available remote playback devices">
+                    monitoring the list of available remote playback devices</a>,
+                    run the algorithm to <a>monitor the list of available remote
+                    playback devices</a>.
                   </li>
                 </ol>
               </li>
             </ol>
             <p class="note">
-              A simple algorithm for assigning <var>callbackId</var> values is
+              A simple algorithm for assigning |callbackId| values is
               to keep a counter for each <a>browsing context</a> and
               incrementing it in step 6.
             </p>
             <div class="note">
               To avoid leaking information that could fingerprint the user, the
-              user agent is expected not to assign a <var>callbackId</var> that
+              user agent is expected not to assign a |callbackId| that
               uses any persistent information from the browser profile or a
               <a>remote playback device</a>.
             </div>
@@ -734,38 +744,43 @@
               devices</dfn> by running the following steps:
             </p>
             <ol>
-              <li>Retrieve available remote playback devices (using an
-              implementation specific mechanism) and let <var>newDevices</var>
-              be this list.
+              <li>
+                Retrieve available remote playback devices (using an
+                implementation specific mechanism) and let |newDevices:list|
+                be this list.
               </li>
-              <li>For each <a>media element</a> known to the <a>browsing
-              context</a>:
+              <li>
+                For each <a>media element</a> known to the <a>browsing
+                context</a>:
                 <ol>
-                  <li>If the <a data-link-for=
-                  "HTMLMediaElement">disableRemotePlayback</a> attribute is
-                  present for <var>mediaElement</var>, abort all the remaining
-                  steps for this tuple and continue to the next one.
+                  <li>
+                    If the <a data-link-for="HTMLMediaElement">disableRemotePlayback</a>
+                    attribute is present for |mediaElement:HTMLMediaElement|, abort all
+                    the remaining steps for this tuple and continue to the next one.
                   </li>
-                  <li>Set <var>newAvailabilityValue</var> to the value of
-                  <a>availability</a> for the <a>media element</a> calculated
-                  using the <var>newDevices</var> list instead of the <a>list
-                  of available remote playback devices</a>.
+                  <li>
+                    Set |newAvailabilityValue:boolean| to the value of
+                    <a>availability</a> for the <a>media element</a> calculated
+                    using the |newDevices| list instead of the <a>list
+                    of available remote playback devices</a>.
                   </li>
-                  <li>If the current <a>availability</a> is not equal to <var>
-                    newAvailabilityValue</var>, then for each
-                    <em>(<var>callbackId</var>, <var>callback</var>)</em> of
-                    the element's <a>set of availability callbacks</a>:
+                  <li>
+                    If the current <a>availability</a> is not equal to
+                    |newAvailabilityValue|, then for each <em>(|callbackId:long|,
+                    |callback:RemotePlaybackAvailabilityCallback|)</em>
+                    of the element's <a>set of availability callbacks</a>:
                     <ol>
                       <li>
-                        <a>Queue a task</a> to invoke <var>callback</var> with
-                        <var>newAvailabilityValue</var> as its argument.
+                        <a>Queue a task</a> to invoke |callback| with
+                        |newAvailabilityValue| as its argument.
                       </li>
                     </ol>
                   </li>
                 </ol>
               </li>
-              <li>Set the <a>list of available remote playback devices</a> to
-              the value of <var>newDevices</var>.
+              <li>
+                Set the <a>list of available remote playback devices</a> to
+                the value of |newDevices|.
               </li>
             </ol>
           </section>
@@ -774,51 +789,59 @@
               Stop observing remote playback devices availability
             </h5>
             <p>
-              When a <code><dfn data-dfn-for=
-              "RemotePlayback">cancelWatchAvailability</dfn>()</code> method is
-              called, the <a>user agent</a> MUST run the following steps:
+              When a <dfn data-dfn-for="RemotePlayback">`cancelWatchAvailability`
+              </dfn>`()` method is called, the <a>user agent</a> MUST run the
+              following steps:
             </p>
             <dl>
               <dt>
                 Input
               </dt>
               <dd>
-                <var>id</var>, the callback identifier.
+                |id:long|, the callback identifier.
               </dd>
               <dt>
                 Output
               </dt>
               <dd>
-                <var>promise</var>, a promise.
+                |promise:Promise|, a {{Promise}}.
               </dd>
             </dl>
             <ol>
-              <li>Let <var>promise</var> be a new promise.
+              <li>
+                Let |promise| be a new {{Promise}}.
               </li>
-              <li>Return <var>promise</var>, and run the following steps below:
+              <li>
+                Return |promise|, and run the following steps below:
               </li>
-              <li>If the <a data-link-for=
-              "HTMLMediaElement">disableRemotePlayback</a> attribute is present
-              for the <a>media element</a>, reject <var>promise</var> with
-              {{InvalidStateError}} and abort all the remaining steps.
+              <li>
+                If the <a data-link-for=
+                "HTMLMediaElement">disableRemotePlayback</a> attribute is present
+                for the <a>media element</a>, reject |promise| with
+                {{InvalidStateError}} and abort all the remaining steps.
               </li>
-              <li>If the parameter <var>id</var> is <code>undefined</code>,
-              clear the <a>set of availability callbacks</a>.
+              <li>
+                If the parameter |id| is `undefined`,
+                clear the <a>set of availability callbacks</a>.
               </li>
-              <li>Otherwise, if <var>id</var> matches the <var>callbackId</var>
-              for any entry in the <a>set of availability callbacks</a>, remove
-              the entry from the set.
+              <li>
+                Otherwise, if |id| matches the |callbackId:long|
+                for any entry in the <a>set of availability callbacks</a>, remove
+                the entry from the set.
               </li>
-              <li>Otherwise, reject <var>promise</var> with
-              {{NotFoundError}} and abort all the remaining steps.
+              <li>
+                Otherwise, reject |promise| with
+                {{NotFoundError}} and abort all the remaining steps.
               </li>
-              <li>If the <a>set of availability callbacks</a> is now empty and
-              there is no pending request to <a data-lt="prompt">
-              initiate remote playback</a>, cancel any pending task to
-              <a>monitor the list of available remote playback devices</a>
-              for power saving purposes.
+              <li>
+                If the <a>set of availability callbacks</a> is now empty and
+                there is no pending request to
+                <a data-lt="prompt">initiate remote playback</a>, cancel any
+                pending task to <a>monitor the list of available remote
+                playback devices</a> for power saving purposes.
               </li>
-              <li>Fulfill <var>promise</var>.
+              <li>
+                Fulfill |promise|.
               </li>
             </ol>
             <div class="note">
@@ -834,8 +857,8 @@
             Prompt user for changing remote playback state
           </h4>
           <p>
-            When the <code><dfn data-dfn-for=
-            "RemotePlayback">prompt</dfn>()</code> method is called, the
+            When the <dfn data-dfn-for=
+            "RemotePlayback">`prompt`</dfn>`()` method is called, the
             <a>user agent</a> MUST run the following steps:
           </p>
           <dl>
@@ -851,42 +874,48 @@
               Output
             </dt>
             <dd>
-              A promise.
+              A {{Promise}}.
             </dd>
           </dl>
           <ol>
-            <li>Let <var>promise</var> be a new promise.
+            <li>
+              Let |promise:Promise| be a new {{Promise}}.
             </li>
-            <li>Return <var>promise</var> and continue running these steps <a>
-              in parallel</a>.
+            <li>
+              Return |promise| and continue running these steps
+              <a>in parallel</a>.
             </li>
-            <li>If the <a data-link-for=
-            "HTMLMediaElement">disableRemotePlayback</a> attribute is present
-            for the <a>media element</a>, reject the <var>promise</var> with
-            {{InvalidStateError}} and abort all the remaining steps.
+            <li>
+              If the <a data-link-for=
+              "HTMLMediaElement">disableRemotePlayback</a> attribute is present
+              for the <a>media element</a>, reject the |promise| with
+              {{InvalidStateError}} and abort all the remaining steps.
             </li>
-            <li>If there is already an unsettled promise from a previous call
-            to <a>prompt</a> for the same <a>media element</a> or even for
-            the same <a>browsing context</a>, the user agent MAY reject
-            <var>promise</var> with an {{OperationError}} exception and abort all
-            remaining steps.
+            <li>
+              If there is already an unsettled promise from a previous call
+              to <a>prompt</a> for the same <a>media element</a> or even for
+              the same <a>browsing context</a>, the user agent MAY reject
+              |promise| with an {{OperationError}} exception and abort all
+              remaining steps.
               <div class="note">
                 The rationale here is that the user agent might show a dialog
                 that's modal to either the <a>media element</a> or the
                 <a>browsing context</a>. In such a case, the second call to
-                <code><a>prompt</a>()</code> would not be able to show any UI.
+                <a>`prompt`</a>`()` would not be able to show any UI.
               </div>
             </li>
-            <li>If the algorithm isn't <a data-cite="HTML#allowed-to-show-a-popup">
-            allowed to show a popup</a>, reject <var>promise</var> with an
-            {{InvalidAccessError}} exception and abort these steps.
+            <li>
+              If the algorithm isn't <a data-cite="HTML#allowed-to-show-a-popup">
+              allowed to show a popup</a>, reject |promise| with an
+              {{InvalidAccessError}} exception and abort these steps.
             </li>
-            <li>OPTIONALLY, if the <a>user agent</a> knows a priori that remote
-            playback of this particular <a>media element</a> is not feasible
-            (independent of the current <code><a>state</a></code> or
-            the <a>list of available remote playback devices</a>),
-            reject <var>promise</var> with a {{NotSupportedError}} and abort
-            all remaining steps.
+            <li>
+              OPTIONALLY, if the <a>user agent</a> knows a priori that remote
+              playback of this particular <a>media element</a> is not feasible
+              (independent of the current <a>`state`</a> or the
+              <a>list of available remote playback devices</a>),
+              reject |promise| with a {{NotSupportedError}} and abort
+              all remaining steps.
               <div class="note">
                 An example of this situation is when the user agent only
                 supports <a>media flinging</a>, and the media element's source
@@ -894,20 +923,23 @@
                 <a>remote playback device</a>.
               </div>
             </li>
-            <li>If the <a>user agent</a> needs to show the <a>list of available
-            remote playback devices</a> and is not <a data-lt=
-            "monitor the list of available remote playback devices">monitoring
-            the list of available remote playback devices</a>, run the steps to
-            <a>monitor the list of available remote playback devices</a> <a>in
-            parallel</a>.
+            <li>
+              If the <a>user agent</a> needs to show the <a>list of available
+              remote playback devices</a> and is not <a data-lt=
+              "monitor the list of available remote playback devices">monitoring
+              the list of available remote playback devices</a>, run the steps to
+              <a>monitor the list of available remote playback devices</a> <a>in
+              parallel</a>.
             </li>
-            <li>If remote playback is <a>unavailable</a> and will remain so
-            before the request for user permission is complete,
-            reject <var>promise</var> with a {{NotFoundError}} exception and
-            abort all remaining steps.
+            <li>
+              If remote playback is <a>unavailable</a> and will remain so
+              before the request for user permission is complete,
+              reject |promise| with a {{NotFoundError}} exception and
+              abort all remaining steps.
             </li>
-            <li>Request user permission to <dfn>change remote playback
-            state</dfn>.
+            <li>
+              Request user permission to <dfn>change remote playback
+              state</dfn>.
               <div class="note">
                 An example UI to request permission would allow the user to
                 pick a new <a>remote playback device</a>, switch between local
@@ -922,15 +954,17 @@
                 proceed immediately to the next step.
               </div>
             </li>
-            <li>If the user picked a <a>remote playback device</a>
-            <var>device</var> to <dfn>initiate remote playback</dfn> with, the
-            <a>user agent</a> MUST run the following steps:
+            <li>
+              If the user picked a <a>remote playback device</a>
+              |device:remote playback device| to <dfn>initiate remote playback</dfn>
+              with, the <a>user agent</a> MUST run the following steps:
               <ol>
-                <li>Set the <a>state</a> of the
-                <var>remote</var> object to <a data-link-for=
-                "RemotePlaybackState">connecting</a>.
+                <li>
+                  Set the <a>state</a> of the |remote:RemotePlayback| object
+                  to <a data-link-for="RemotePlaybackState">connecting</a>.
                 </li>
-                <li>Fulfill <var>promise</var>.
+                <li>
+                  Fulfill |promise|.
                 </li>
                 <li>
                   <a>Queue a task</a> to <a>fire an event</a> with the
@@ -941,7 +975,7 @@
                 </li>
                 <li>
                   <a>Establish a connection with the remote playback device</a>
-                  <var>device</var> for the <a>media element</a>.
+                  |device| for the <a>media element</a>.
                 </li>
               </ol>
               <p class="note">
@@ -949,21 +983,24 @@
                 permission</em> to use the device.
               </p>
             </li>
-            <li>Otherwise, if the user chose to disconnect from the <a>remote
-            playback device</a> <var>device</var>, the <a>user agent</a> MUST
-            run the following steps:
+            <li>
+              Otherwise, if the user chose to disconnect from the <a>remote
+              playback device</a> |device|, the <a>user agent</a> MUST
+              run the following steps:
               <ol>
-                <li>Fulfill <var>promise</var>.
+                <li>
+                  Fulfill |promise|.
                 </li>
-                <li>Run the <a>disconnect from a remote playback device</a>
-                algorithm for the <var>device</var>.
+                <li>
+                  Run the <a>disconnect from a remote playback device</a>
+                  algorithm for the |device|.
                 </li>
               </ol>
             </li>
-            <li>Otherwise, the user is considered to <em>deny permission</em>
-            to use the device, so reject <var>promise</var> with
-            {{NotAllowedError}} exception and hide the UI shown by the
-            <a>user agent</a>.
+            <li>
+              Otherwise, the user is considered to <em>deny permission</em>
+              to use the device, so reject |promise| with {{NotAllowedError}}
+              exception and hide the UI shown by the <a>user agent</a>.
             </li>
           </ol>
           <div class="note">
@@ -991,10 +1028,10 @@
         </section>
         <section data-link-for="RemotePlayback">
           <h4>
-            The <code><a>state</a></code> attribute
+            The <a>`state`</a> attribute
           </h4>
           <p>
-            The <dfn data-dfn-for="RemotePlayback"><code>state</code></dfn>
+            The <dfn data-dfn-for="RemotePlayback">`state`</dfn>
             attribute represents the <a>RemotePlayback</a> connection's current
             state. It can take one of the values of <a>RemotePlaybackState</a>
             depending on the connection state:
@@ -1004,10 +1041,9 @@
               <dfn>connecting</dfn> means that the user agent is attempting to
               <a>initiate remote playback</a> with the selected <a>remote
               playback device</a>. This is the initial state when the
-              <code>promise</code> returned by <code><a>prompt</a>()</code>
-              is fulfilled. The local playback of the media element continues
-              in this state and media commands still take effect on the
-              <a>local playback state</a>.
+              `promise` returned by <a>`prompt`</a>`()` is fulfilled. The local
+              playback of the media element continues in this state and media
+              commands still take effect on the <a>local playback state</a>.
             </li>
             <li>
               <dfn>connected</dfn> means that the transition from local to
@@ -1019,8 +1055,7 @@
               been <a data-lt="initiate remote playback">initiated</a>, has
               failed to initiate or has been stopped. All media commands will
               take effect on the <a>local playback state</a>. The remote
-              playback can be initiated through a call to
-              <code><a>prompt</a>()</code>.
+              playback can be initiated through a call to <a>`prompt`</a>`()`.
             </li>
           </ul>
         </section>
@@ -1037,49 +1072,53 @@
               Input
             </dt>
             <dd>
-              <var>remote</var>, the <a>RemotePlayback</a> object that is to be
+              |remote:RemotePlayback|, the <a>RemotePlayback</a> object that is to be
               connected.
             </dd>
             <dd>
-              <var>device</var>, the <a>remote playback device</a> to connect
-              to.
+              |device:remote playback device|, the <a>remote playback device</a> to
+              connect to.
             </dd>
           </dl>
           <ol>
-            <li>If the <code><a>state</a></code> of <var>remote</var> is not equal
-            to <a data-link-for="RemotePlaybackState">connecting</a>, abort all
-            the remaining steps.
+            <li>
+              If the <a>`state`</a> of |remote| is not equal to
+              <a data-link-for="RemotePlaybackState">connecting</a>,
+              abort all the remaining steps.
             </li>
-            <li>Request connection of <var>remote</var> to <var>device</var>.
-            The implementation of this step is specific to the <a>user
-            agent</a>.
+            <li>
+              Request connection of |remote| to |device|. The implementation
+              of this step is specific to the <a>user agent</a>.
             </li>
-            <li>If connection completes successfully, <a>queue a task</a> to
-            run the following steps:
+            <li>
+              If connection completes successfully, <a>queue a task</a> to
+              run the following steps:
               <ol>
-                <li>Set the <a>state</a> of <var>remote</var> to
-                <a data-link-for="RemotePlaybackState">connected</a>.
+                <li>
+                  Set the <a>state</a> of |remote| to
+                  <a data-link-for="RemotePlaybackState">connected</a>.
                 </li>
                 <li>
-                  <a>Fire an event</a> named <a>connect</a> at
-                  <var>remote</var>.
+                  <a>Fire an event</a> named <a>connect</a> at |remote|.
                 </li>
-                <li>Synchronize the current <a>media element state</a> with the
-                <a>remote playback state</a>. The implementation of this step
-                is specific to the <a>user agent</a>.
+                <li>
+                  Synchronize the current <a>media element state</a> with the
+                  <a>remote playback state</a>. The implementation of this step
+                  is specific to the <a>user agent</a>.
                 </li>
               </ol>
             </li>
-            <li>If connection fails, <a>queue a task</a> to run the following
-            steps:
+            <li>
+              If connection fails, <a>queue a task</a> to run the following
+              steps:
               <ol>
-                <li>Set the <a data-lt="state">
-                  remote playback state</a> of <var>remote</var> to
+                <li>
+                  Set the <a data-lt="state">
+                  remote playback state</a> of |remote| to
                   <a data-link-for="RemotePlaybackState">disconnected</a>.
                 </li>
                 <li>
-                  <a>Fire an event</a> named <a>disconnect</a> at
-                  <var>remote</var>.
+                  <a>Fire an event</a> named <a>disconnect</a> at |remote|.
                 </li>
               </ol>
             </li>
@@ -1114,7 +1153,7 @@
             that reflect the user's preferences. For example, the <a>remote
             playback device</a> can use that information to choose the same
             default text track as the user agent, as well as to set the HTTP
-            <code>Accept-Language</code> header it sends to fetch media
+            `Accept-Language` header it sends to fetch media
             resources.
           </div>
           <div class="note">
@@ -1223,8 +1262,8 @@
               For example, after calling <code>{{HTMLMediaElement/fastSeek()}}</code>
               while connected to a <a>remote playback device</a> that does not
               support it, the <code>{{HTMLMediaElement/seeking}}</code> attribute of the
-              {{HTMLMediaElement}} is expected to remain <code>false</code> and no
-              <code><a data-cite="HTML#event-media-seeking">seeking</a></code> event is to be fired.
+              {{HTMLMediaElement}} is expected to remain `false` and no
+              <a data-cite="HTML#event-media-seeking">`seeking`</a> event is to be fired.
             </p>
           </div>
         </section>
@@ -1241,35 +1280,37 @@
               Input
             </dt>
             <dd>
-              <var>remote</var>, the <a>RemotePlayback</a> object representing
-              the playback to be stopped.
+              |remote:RemotePlayback|, the <a>RemotePlayback</a> object
+              representing the playback to be stopped.
             </dd>
             <dd>
-              <var>device</var>, the <a>remote playback device</a> to
-              disconnect from.
+              |device:remote playback device|, the <a>remote playback device</a>
+              to disconnect from.
             </dd>
           </dl>
           <ol>
-            <li>If the <a data-link-for="RemotePlayback"><code>state</code></a>
-            of <var>remote</var> is <code>disconnected</code>, abort all
-            remaining steps.
+            <li>
+              If the <a data-link-for="RemotePlayback">`state`</a>
+              of |remote| is `disconnected`, abort all remaining steps.
             </li>
             <li>
               <a>Queue a task</a> to run the following steps:
               <ol>
-                <li>Request disconnection of <var>remote</var> from the
-                <var>device</var>. The implementation of this step is
-                specific to the <a>user agent</a>.
-                </li>
-                <li>Change the <var>remote</var>'s <code>state</code> to <code>
-                  disconnected</code>.
+                <li>
+                  Request disconnection of |remote| from the
+                  |device|. The implementation of this step is
+                  specific to the <a>user agent</a>.
                 </li>
                 <li>
-                  <a>Fire an event</a> with the name <a>disconnect</a> at <var>remote</var>.
+                  Change the |remote|'s `state` to `disconnected`.
                 </li>
-                <li>Synchronize the current <a>media element state</a> with the
-                <a>local playback state</a>. The implementation of this step is
-                specific to the <a>user agent</a>.
+                <li>
+                  <a>Fire an event</a> with the name <a>disconnect</a> at |remote|.
+                </li>
+                <li>
+                  Synchronize the current <a>media element state</a> with the
+                  <a>local playback state</a>. The implementation of this step is
+                  specific to the <a>user agent</a>.
                 </li>
               </ol>
             </li>
@@ -1290,8 +1331,7 @@
             implementation of the user agent and the remote playback device.
             In this case, stopping remote playback means that the user agent
             merely disconnects from the remote playback device and the
-            <a>media element</a> switches to the <code>disconnected</code>
-            state.
+            <a>media element</a> switches to the `disconnected` state.
           </div>
         </section>
         <section>
@@ -1318,26 +1358,26 @@
             <tbody>
               <tr>
                 <td>
-                  <dfn><code>onconnecting</code></dfn>
+                  <dfn>`onconnecting`</dfn>
                 </td>
                 <td>
-                  <dfn><code>connecting</code></dfn>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <dfn><code>onconnect</code></dfn>
-                </td>
-                <td>
-                  <dfn><code>connect</code></dfn>
+                  <dfn>`connecting`</dfn>
                 </td>
               </tr>
               <tr>
                 <td>
-                  <dfn><code>ondisconnect</code></dfn>
+                  <dfn>`onconnect`</dfn>
                 </td>
                 <td>
-                  <dfn><code>disconnect</code></dfn>
+                  <dfn>`connect`</dfn>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <dfn>`ondisconnect`</dfn>
+                </td>
+                <td>
+                  <dfn>`disconnect`</dfn>
                 </td>
               </tr>
             </tbody>
@@ -1362,21 +1402,20 @@
         </p>
         <section data-link-for="HTMLMediaElement">
           <h4>
-            The <dfn><code>disableRemotePlayback</code></dfn> attribute
+            The <dfn>`disableRemotePlayback`</dfn> attribute
           </h4>
           <p>
             Some pages may wish to disable remote playback of a media element;
-            for example, they may prefer to use a <code><a data-cite=
-            "PRESENTATION-API#interface-presentationrequest">PresentationRequest</a></code>
+            for example, they may prefer to use a <a data-cite=
+            "PRESENTATION-API#interface-presentationrequest">`PresentationRequest`</a>
             to present a complete document on a presentation screen. To support
-            this use case, a new <code>disableRemotePlayback</code> attribute is
-            added to the list of content attributes for <code>audio</code>
-            and <code>video</code> elements.
+            this use case, a new `disableRemotePlayback` attribute is added to
+            the list of content attributes for `audio` and `video` elements.
           </p>
           <p>
             A corresponding <a>disableRemotePlayback</a> IDL attribute which
-            reflects the value of each element's <code>disableRemotePlayback</code>
-            content attribute is added to the <code>HTMLMediaElement</code> interface.
+            reflects the value of each element's `disableRemotePlayback`
+            content attribute is added to the `HTMLMediaElement` interface.
             The <a>disableRemotePlayback</a> IDL attribute MUST
             <a data-cite="HTML#reflecting-content-attributes-in-idl-attributes">
             reflect</a> the content attribute of the same name.
@@ -1404,7 +1443,7 @@
             element.
             </li>
             <li>If its <a data-link-for="RemotePlayback">state</a> is not
-            <code>disconnected</code>, run the <a>disconnect from a remote
+            `disconnected`, run the <a>disconnect from a remote
             playback device</a> algorithm for the <a>remote playback device</a>
             the media element is connected or connecting to.
             </li>
@@ -1421,9 +1460,8 @@
           Personally identifiable information
         </h3>
         <p>
-          Firing the <code>callback</code> provided via the
-          <code><a data-link-for=
-          "RemotePlayback">watchAvailability</a>()</code> method reveals one
+          Firing the `callback` provided via the <a data-link-for=
+          "RemotePlayback">`watchAvailability`</a>`()` method reveals one
           bit of information about the presence (or non-presence) of a
           <a>remote playback device</a> typically discovered through the local
           area network. This could be used in conjunction with other
@@ -1476,8 +1514,7 @@
             <p>
               Showing the origin that will be presented will help the user know
               if that content is from a <a>potentially trustworthy origin</a>
-              (e.g., <code>https:</code>), and corresponds to a known or
-              expected site.
+              (e.g., `https:`), and corresponds to a known or expected site.
             </p>
           </dd>
         </dl>


### PR DESCRIPTION
- Use `` instead of \<code>\</code>
- Use |variable:Type| instead of \<var>\</var>

Splitted from #133


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Honry/remote-playback/pull/135.html" title="Last updated on Apr 15, 2020, 5:29 AM UTC (ede961a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/remote-playback/135/9e3da8a...Honry:ede961a.html" title="Last updated on Apr 15, 2020, 5:29 AM UTC (ede961a)">Diff</a>