### PR TITLE
Fix "allowed to show a popup" concept

### DIFF
--- a/index.html
+++ b/index.html
@@ -917,8 +917,8 @@
               </div>
             </li>
             <li>
-              If the algorithm isn't <a data-cite="HTML#allowed-to-show-a-popup">
-              allowed to show a popup</a>, reject |promise| with an
+              If the document's [=browsing context/active window=] does not have
+              [=transient activation=], reject |promise| with an
               {{InvalidAccessError}} exception and abort these steps.
             </li>
             <li>


### PR DESCRIPTION
The "allowed to show a popup" concept no longer exist in HTML and thus the link to "allowed to show a popup" is now a broken link.

Tracking user activation is to be done through the concepts of sticky/transient activation:
https://html.spec.whatwg.org/multipage/interaction.html#user-activation-data-model

This update replaces "isn't allowed to show a popup" with "does not have transient activation".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/remote-playback/pull/142.html" title="Last updated on Dec 10, 2020, 9:48 AM UTC (18201f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/remote-playback/142/1612ad8...tidoust:18201f8.html" title="Last updated on Dec 10, 2020, 9:48 AM UTC (18201f8)">Diff</a>