### PR TITLE
Fix markup for definition of watchAvailability()

### DIFF
--- a/index.html
+++ b/index.html
@@ -646,8 +646,8 @@
               information
             </h5>
             <p>
-              When the <dfn>`watchAvailability`</dfn>`()` method is
-              called, the user agent MUST run the following steps:
+              When the <dfn data-dfn-for="RemotePlayback">watchAvailability</dfn>`()`
+              method is called, the user agent MUST run the following steps:
             </p>
             <dl>
               <dt>


### PR DESCRIPTION
The definition was missing a `data-dfn-for` and ReSpec failed to associate it with the `RemotePlayback` interface.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/remote-playback/pull/145.html" title="Last updated on Apr 14, 2022, 4:14 PM UTC (136044a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/remote-playback/145/86030d8...tidoust:136044a.html" title="Last updated on Apr 14, 2022, 4:14 PM UTC (136044a)">Diff</a>