### PR TITLE
Enable auto-publication of the spec to /TR

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,18 @@
+name: Build, Validate, Deploy and Publish
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+jobs:
+  main:
+    name: Build and validate spec, then deploy and publish (only if push to main branch)
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          GH_PAGES_BRANCH: gh-pages
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-secondscreen/2022Apr/0007.html
+          W3C_BUILD_OVERRIDE: |
+            specStatus: CRD

--- a/ECHIDNA
+++ b/ECHIDNA
@@ -1,2 +1,0 @@
-# ECHIDNA configuration
-index.html?specStatus=WD;shortName=remote-playback respec

--- a/index.html
+++ b/index.html
@@ -38,15 +38,6 @@
         // previousPublishDate: '2015-11-02',
         otherLinks: [
           {
-            key: 'Version history',
-            data: [
-              {
-                value: 'GitHub w3c/remote-playback/commits',
-                href: 'https://github.com/w3c/remote-playback/commits/'
-              }
-            ]
-          },
-          {
             key: 'Test suite',
             data: [
               {
@@ -58,30 +49,10 @@
                 href: 'https://w3c-test.org/remote-playback/'
               }
             ]
-          },
-          {
-            key: 'Participate',
-            data: [
-              {
-                value: 'GitHub w3c/remote-playback',
-                href: 'https://github.com/w3c/remote-playback/'
-              },
-              {
-                value: 'File an issue',
-                href: 'https://github.com/w3c/remote-playback/issues/new'
-              },
-              {
-                value: 'Open issues',
-                href: 'https://github.com/w3c/remote-playback/issues/'
-              },
-              {
-                value: 'Mailing-list (public-secondscreen@w3.org)',
-                href: 'https://lists.w3.org/Archives/Public/public-secondscreen/'
-              }
-            ]
           }
         ],
         group: 'secondscreen',
+        github: 'https://github.com/w3c/remote-playback',
         implementationReportURI: 'https://www.w3.org/wiki/Second_Screen/Implementation_Status#Remote_Playback_API'
       };
     </script>

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
         ],
         group: 'secondscreen',
         github: 'https://github.com/w3c/remote-playback',
+        crEnd: '2017-11-30',
         implementationReportURI: 'https://www.w3.org/wiki/Second_Screen/Implementation_Status#Remote_Playback_API'
       };
     </script>

--- a/index.html
+++ b/index.html
@@ -1200,28 +1200,28 @@
             the <a>media element state</a>, and the <a>remote playback
             state</a>:
           </p>
-          <dl>
-            <dd>
+          <ul>
+            <li>
               The <a>user agent</a> MUST send all media commands issued on the
               associated {{HTMLMediaElement}} object to the <a>remote playback
               device</a> in order to change its <a>remote playback state</a>;
-            </dd>
-            <dd>
+            </li>
+            <li>
               The <a>remote playback device</a> SHOULD implement all media
               commands sent by the <a>user agent</a>;
-            </dd>
-            <dd>
+            </li>
+            <li>
               The <a>remote playback device</a> SHOULD send updates of
               the <a>remote playback state</a> to the <a>user agent</a> that
               affect any attribute exposed through the <a>media element
               state</a>;
-            <dd>
+            <li>
               The <a>user agent</a> MUST process all updates of the
               <a>remote playback state</a> received from the <a>remote playback
               device</a> and update the <a>local playback state</a> of the
               media element accordingly.
-            </dd>
-          </dl>
+            </li>
+          </ul>
           <p>
             If sending any command fails, the <a>user agent</a> MAY
             <a>disconnect from a remote playback device</a>.


### PR DESCRIPTION
This update enables auto-publication of the spec as Candidate Recommendation Draft to /TR, as agreed by the working group. It leverages the [spec-prod action](https://github.com/w3c/spec-prod/) to do that.

This update also adjusts the workflow for the Editor's Draft itself. The source spec is now to be found in the `main` branch, and instead of publishing the source spec to GitHub Pages directly, the spec-prod action will rather deploy the generated spec. Among other things, this makes it possible to integrate the spec in Bikeshed's database for cross-referencing purpose (fixing #137).

The spec-prod action also takes care of running ReSpec on pull requests to validate changes from an editorial perspective.

Note the `ECHIDNA_TOKEN` was added as secret to the repository.

Related PR for the Presentation API: https://github.com/w3c/presentation-api/pull/502


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/remote-playback/pull/146.html" title="Last updated on Apr 15, 2022, 4:16 PM UTC (71dba50)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/remote-playback/146/737f708...tidoust:71dba50.html" title="Last updated on Apr 15, 2022, 4:16 PM UTC (71dba50)">Diff</a>