### PR TITLE
Add Picture in Picture window to note on local playback devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -339,7 +339,8 @@
         </p>
         <div class="note">
           A <a>local playback device</a> might have extra outputs, like an
-          external display or speakers/headphones. As long as the switch of
+          external display or speakers/headphones, or a Picture-in-Picture
+          window [[Picture-in-Picture]]. As long as the switch of
           what output to use happens outside of the user agent on the
           system level, the playback is considered to happen on a <a>local
           playback device</a> for the purpose of this spec.


### PR DESCRIPTION
For context, see https://github.com/w3c/picture-in-picture/issues/191.

The Picture in Picture spec currently says:

> The [[Remote-Playback]](https://w3c.github.io/picture-in-picture/#biblio-remote-playback) specification defines a [local playback device](https://w3c.github.io/remote-playback/#dfn-local-playback-device) and a [local playback state](https://w3c.github.io/remote-playback/#dfn-local-playback-state). For the purpose of Picture-in-Picture, the playback is local and regardless of whether it is played in page or in Picture-in-Picture.

Media WG would like to move this language to the Remote Playback API to avoid having a patch in the Picture in Picture spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/remote-playback/pull/153.html" title="Last updated on Mar 21, 2024, 10:59 AM UTC (5a1e7fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/remote-playback/153/81d1d58...5a1e7fe.html" title="Last updated on Mar 21, 2024, 10:59 AM UTC (5a1e7fe)">Diff</a>