### PR TITLE
Update ReSpec references to HTML.

### DIFF
--- a/index.html
+++ b/index.html
@@ -889,7 +889,7 @@
               </div>
             </li>
             <li>
-              If the document's [=browsing context/active window=] does not have
+              If the document's [=navigable/active window=] does not have
               [=transient activation=], reject |promise| with an
               {{InvalidAccessError}} exception and abort these steps.
             </li>
@@ -1475,10 +1475,9 @@
             <p>
               Display of the origin requesting remote playback will help the
               user understand what content is making the request, especially
-              when the request is initiated from a <a>nested browsing
-              context</a>. For example, embedded content may try to convince
-              the user to click to trigger a request to start an unwanted
-              remote playback.
+              when the request is initiated from a [=child navigable=]. For
+              example, embedded content may try to convince the user to click to
+              trigger a request to start an unwanted remote playback.
             </p>
             <p>
               Showing the origin that will be presented will help the user know


### PR DESCRIPTION
This fixes ReSpec errors as xrefs to terms in HTML have changed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/remote-playback/pull/154.html" title="Last updated on Mar 22, 2024, 5:03 PM UTC (6390db3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/remote-playback/154/81d1d58...6390db3.html" title="Last updated on Mar 22, 2024, 5:03 PM UTC (6390db3)">Diff</a>