### PR TITLE
fix typo in example

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,7 +275,7 @@
         <pre class="example">
 &lt;!-- player.html --&gt;
 &lt;script&gt;
-  devicesBtn.onclick = () => {
+  deviceBtn.onclick = () => {
     // Request the user to select a remote playback device.
     videoElem.remote.prompt()
       // Update the UI and monitor the connected state.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/troggy/remote-playback/pull/155.html" title="Last updated on Apr 15, 2024, 8:21 AM UTC (7ce6721)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/remote-playback/155/ac9a2bb...troggy:7ce6721.html" title="Last updated on Apr 15, 2024, 8:21 AM UTC (7ce6721)">Diff</a>